### PR TITLE
Fancy Property files

### DIFF
--- a/src/com/blazeloader/api/block/ApiBlock.java
+++ b/src/com/blazeloader/api/block/ApiBlock.java
@@ -28,7 +28,27 @@ public class ApiBlock {
     public static Block getBlockByNameOrId(String identifier) {
         return MathUtils.isInteger(identifier) ? getBlockById(Integer.parseInt(identifier)) : getBlockByName(identifier);
     }
-
+    
+    /**
+     * Gets the name of a block.
+     *
+     * @param block The block to get the name for
+     * @return Return a string of the name belonging to param block
+     */
+    public static ResourceLocation getBlockName(Block block) {
+        return (ResourceLocation)Block.blockRegistry.getNameForObject(block);
+    }
+    
+    /**
+     * Gets the name of a block.
+     *
+     * @param block The block to get the name for
+     * @return Return a string of the name belonging to param block
+     */
+    public static String getStringBlockName(Block block) {
+        return getBlockName(block).toString();
+    }
+    
     /**
      * Gets a block by it's name
      *
@@ -77,9 +97,12 @@ public class ApiBlock {
      * @param block				The block to register
      * @param encouragement		How likely it is that this block will spread fire
      * @param flamability		How flamable this block is
+     * 
+     * @return the block for simplicity
      */
-    public static void registerFireInfo(Block block, int encouragement, int flamability) {
+    public static <T extends Block> T registerFireInfo(T block, int encouragement, int flamability) {
     	Blocks.fire.setFireInfo(block, encouragement, flamability);
+    	return block;
     }
     
     /**
@@ -237,25 +260,5 @@ public class ApiBlock {
     public static void registerTileEntity(Class<? extends TileEntity> clazz, String name) {
         TileEntity.classToNameMap.put(clazz, name);
         TileEntity.nameToClassMap.put(name, clazz);
-    }
-
-    /**
-     * Gets the name of a block.
-     *
-     * @param block The block to get the name for
-     * @return Return a string of the name belonging to param block
-     */
-    public static ResourceLocation getBlockName(Block block) {
-        return (ResourceLocation)Block.blockRegistry.getNameForObject(block);
-    }
-    
-    /**
-     * Gets the name of a block.
-     *
-     * @param block The block to get the name for
-     * @return Return a string of the name belonging to param block
-     */
-    public static String getStringBlockName(Block block) {
-        return getBlockName(block).toString();
     }
 }

--- a/src/com/blazeloader/api/entity/EntityPropertyManager.java
+++ b/src/com/blazeloader/api/entity/EntityPropertyManager.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import com.blazeloader.bl.main.BLMain;
 import com.mumfrey.liteloader.core.event.HandlerList;
 
+import net.minecraft.crash.CrashReportCategory;
 import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
@@ -87,6 +88,17 @@ public class EntityPropertyManager {
 		}
 	}
 	
+	public static void addEntityCrashInfo(Entity e, CrashReportCategory section) {
+		if (mapping.containsKey(e)) {
+			Properties p = mapping.get(e);
+			try {
+				section.addCrashSection("BlazeLoader Extended Entity Properties", p.getCrashInfo());
+			} catch (Throwable er) {
+				section.addCrashSectionThrowable("BLMod error", er);
+			}
+		}
+	}
+	
 	private static class Properties {
 		private final HandlerList<IEntityProperties> handlers = new HandlerList<IEntityProperties>(IEntityProperties.class);
 		
@@ -116,6 +128,17 @@ public class EntityPropertyManager {
 		
 		public void writeToNBT(NBTTagCompound t) {
 			handlers.all().writeToNBT(t);
+		}
+		
+		public String getCrashInfo() {
+			StringBuilder result = new StringBuilder();
+			result.append("Extended Properties Registered: " + handlers.size());
+			for (IEntityProperties i : handlers) {
+				CrashReportCategory category = new CrashReportCategory(null, "Mod:" + i.getClass().toString());
+				i.addEntityCrashInfo(category);
+				category.appendToStringBuilder(result);
+			}
+			return result.toString();
 		}
 	}
 }

--- a/src/com/blazeloader/api/entity/IEntityProperties.java
+++ b/src/com/blazeloader/api/entity/IEntityProperties.java
@@ -1,5 +1,6 @@
 package com.blazeloader.api.entity;
 
+import net.minecraft.crash.CrashReportCategory;
 import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
@@ -23,4 +24,11 @@ public interface IEntityProperties {
 	 * @param tagCompound
 	 */
 	public void readFromNBT(NBTTagCompound tagCompund);
+	
+	/**
+	 * Used if the game crashes. Put stuff you want to know in the crash report from here.
+	 * 
+	 * @param catagory	CrashReportCategory for this IEntityProperty.
+	 */
+	public void addEntityCrashInfo(CrashReportCategory catagory);
 }

--- a/src/com/blazeloader/bl/main/BLMainClient.java
+++ b/src/com/blazeloader/bl/main/BLMainClient.java
@@ -64,8 +64,6 @@ public class BLMainClient extends BLMain {
         return true;
     }
     
-    //...why?
-    //...because.
     @Override
     public BLMainClient getClient() {
         return this;

--- a/src/com/blazeloader/event/handlers/InternalEventHandler.java
+++ b/src/com/blazeloader/event/handlers/InternalEventHandler.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import net.minecraft.client.ClientBrandRetriever;
 import net.minecraft.command.CommandHandler;
 import net.minecraft.crash.CrashReport;
+import net.minecraft.crash.CrashReportCategory;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.nbt.NBTTagCompound;
@@ -78,5 +79,9 @@ public class InternalEventHandler {
     
     public static void eventCopyDataFromOld(EventInfo<Entity> event, Entity old) {
     	EntityPropertyManager.copyToEntity(old, event.getSource());
+    }
+    
+    public static void eventAddEntityCrashInfo(EventInfo<Entity> event, CrashReportCategory section) {
+    	EntityPropertyManager.addEntityCrashInfo(event.getSource(), section);
     }
 }

--- a/src/com/blazeloader/event/transformers/BLEventInjectionTransformer.java
+++ b/src/com/blazeloader/event/transformers/BLEventInjectionTransformer.java
@@ -79,6 +79,7 @@ public class BLEventInjectionTransformer extends EventInjectionTransformer {
         addBLEvent(EventSide.INTERNAL, "net.minecraft.entity.Entity.writeToNBT (Lnet/minecraft/nbt/NBTTagCompound;)V", beforeReturn);
         addBLEvent(EventSide.INTERNAL, "net.minecraft.entity.Entity.readFromNBT (Lnet/minecraft/nbt/NBTTagCompound;)V", beforeReturn);
         addBLEvent(EventSide.INTERNAL, "net.minecraft.entity.Entity.copyDataFromOld (Lnet/minecraft/entity/Entity;)V", beforeReturn);
+        addBLEvent(EventSide.INTERNAL, "net.minecraft.entity.Entity.addEntityCrashInfo (Lnet/minecraft/crash/CrashReportCategory;)V", beforeReturn);
     }
     
     public String getSide() {

--- a/src/com/blazeloader/util/config/IConfig.java
+++ b/src/com/blazeloader/util/config/IConfig.java
@@ -1,0 +1,59 @@
+package com.blazeloader.util.config;
+
+import java.io.File;
+
+/**
+ * Wrapper object for a config file. Allows loading and saving of properties.
+ */
+public interface IConfig {
+	
+	/**
+	 * Loads the the contents from the given file if it exists.
+	 */
+	public void load(File file);
+	
+	/**
+	 * Saves all keys and values to the underlying file.
+	 */
+	public void save();
+	
+	/**
+	 * Checks if a value with the given name exists in a section of the given section name.
+	 * 
+	 * @param section	Name of section to look in.
+	 * @param name		Name of property to look for.
+	 * 
+	 * @return true if both the section exists and it contains a property by the given name.
+	 */
+	public boolean has(String section, String name);
+	
+	/**
+	 * Gets a property for the given section and name. Creates both if they do not exist and initialises the property to the given default value.
+	 * 
+	 * @param section		Name of the section
+	 * @param name			Name of the property
+	 * @param defaultValue	The default value of the property
+	 * 
+	 * @return	A property object for the given keys.
+	 */
+	public <T> IProperty<T> getProperty(String section, String name, T defaultValue);
+	
+	/**
+	 * Gets a section for the given section name.
+	 */
+	public IPropertyGroup getSection(String section);
+	
+	/**
+	 * Applies a regex to cleanup property names.
+	 * @param name Name to clean
+	 * @return The now safe to use name.
+	 */
+	public String applyNameRegexString(String name);
+	
+	/**
+	 * Applies a regex to cleanup a description/comment.
+	 * @param description The description to clean
+	 * @return The noew safe to use description
+	 */
+	public String applyDescriptionRegexString(String description);
+}

--- a/src/com/blazeloader/util/config/IConfig.java
+++ b/src/com/blazeloader/util/config/IConfig.java
@@ -1,6 +1,7 @@
 package com.blazeloader.util.config;
 
 import java.io.File;
+import java.util.List;
 
 /**
  * Wrapper object for a config file. Allows loading and saving of properties.
@@ -56,4 +57,10 @@ public interface IConfig {
 	 * @return The noew safe to use description
 	 */
 	public String applyDescriptionRegexString(String description);
+	
+	/**
+	 * Gets the next valid line to read from the properties file.
+	 * @param lines List of lines available
+	 */
+	public String popNextLine(List<String> lines);
 }

--- a/src/com/blazeloader/util/config/IProperty.java
+++ b/src/com/blazeloader/util/config/IProperty.java
@@ -1,0 +1,44 @@
+package com.blazeloader.util.config;
+
+/**
+ * Container object of a value-key pair in a config file.
+ *
+ * @param <T> the type of value it contains
+ */
+public interface IProperty<T> {
+	/**
+	 * Sets the default value
+	 */
+	public void setDefault(T newDef);
+	
+	/**
+	 * Sets the curent value back to the default.
+	 */
+	public void reset();
+	
+	/**
+	 * Gets the current value.
+	 * @return
+	 */
+	public T get();
+	
+	/**
+	 * Sets the current value to the given value.
+	 */
+	public void set(T val);
+	
+	/**
+	 * Sets a description/comment to be stored with this property.
+	 */
+	public void setDescription(String desc);
+	
+	/**
+	 * Gets a string representation of the type this property takes.
+	 */
+	public String getType();
+	
+	/**
+	 * The name of this property. Is also the key this property is registered under in config files and categories.
+	 */
+	public String getName();
+}

--- a/src/com/blazeloader/util/config/IPropertyGroup.java
+++ b/src/com/blazeloader/util/config/IPropertyGroup.java
@@ -1,0 +1,38 @@
+package com.blazeloader.util.config;
+
+/**
+ * Container grouping numerous properties together in a config file.
+ */
+public interface IPropertyGroup {
+	
+	/**
+	 * Returns the name attached to the section.
+	 * @return
+	 */
+	public String getName();
+	
+	/**
+	 * Sets a description/comment to store alongside this section. 
+	 */
+	public void setDescription(String desc);
+	
+	/**
+	 * Checks if this group has a property for the given key.
+	 * 
+	 * @param key	The name of the key.
+	 * 
+	 * @return true if the property exists.
+	 */
+	public boolean has(String key);
+	
+	/**
+	 * Gets or adds a new property with the given key and default value.
+	 * 
+	 * @param key	Key to identify the property
+	 * 
+	 * @param def	A default value. If the key does not exist it will be instantiated with this value
+	 *  
+	 * @return Resulting property object.
+	 */
+	public <T> IProperty<T> get(String key, T def);
+}

--- a/src/com/blazeloader/util/config/IStringable.java
+++ b/src/com/blazeloader/util/config/IStringable.java
@@ -1,0 +1,23 @@
+package com.blazeloader.util.config;
+
+/**
+ * Utility interface for adding types you want supported by config files
+ * 
+ * Must have an empty contrsuctor in addition to the below methods.
+ *
+ */
+public interface IStringable {
+	
+	/**
+	 * Just like object. But you really, really need to overrid it.
+	 * @return
+	 */
+	public String toString();
+	
+	/**
+	 * Opposite of toString, converts a string back into an object of this type.
+	 * 
+	 * @param string String representation of an instance of this class
+	 */
+	public IStringable valueOf(String string);
+}

--- a/src/com/blazeloader/util/config/Prop.java
+++ b/src/com/blazeloader/util/config/Prop.java
@@ -1,0 +1,174 @@
+package com.blazeloader.util.config;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Prop<T> implements IProperty<T> {
+	private final IConfig cfg;
+	
+	private static final Map<Class, String> classToType = new HashMap<Class, String>();
+	private static final Map<String, Class> typeToClass = new HashMap<String, Class>();
+	
+	private T currentValue;
+	private T defaultValue;
+	
+	protected final String propertyName;
+	
+	private String description = "";
+	
+	protected boolean loaded = false;
+	
+	protected Prop(IConfig config, List<String> lines) {
+		cfg = config;
+		String first = lines.get(0);
+		if (first.startsWith("\t#")) {
+			description = first.substring(2, first.length());
+			first = lines.get(0);
+			lines.remove(0);
+		}
+		if (first.startsWith("\t@default: ")) {
+			defaultValue = currentValue = (T)first.substring("\t@default: ".length(), first.length());
+			first = lines.get(0);
+			lines.remove(0);
+		}
+		propertyName = first.substring(1, first.length()).split("<")[0];
+		String[] remain = first.substring(propertyName.length() + 1).split(">: ");
+		String type = remain[0].substring(1, remain[0].length());
+		String value = "";
+		for (int i = 1; i < remain.length; i++) {
+			value += remain[i];
+		}
+		currentValue = (T)parseValue(type, value);
+		loaded = true;
+	}
+	
+	protected Prop(IConfig config, String name, T def) {
+		cfg = config;
+		propertyName = cfg.applyNameRegexString(name);
+		defaultValue = def;
+		currentValue = def;
+	}
+	
+	public String getName() {
+		return propertyName;
+	}
+	
+	public void setDefault(T newDef) {
+		defaultValue = newDef;
+	}
+	
+	public void reset() {
+		set(defaultValue);
+	}
+	
+	public T get() {
+		return currentValue;
+	}
+	
+	public void set(T val) {
+		currentValue = val;
+	}
+	
+	public void setDescription(String desc) {
+		if (desc == null) {
+			description = "";
+		} else {
+			description = cfg.applyDescriptionRegexString(desc);
+		}
+	}
+	
+	public String getType() {
+		if (defaultValue instanceof String) return "S";
+		if (defaultValue instanceof Integer) return "I";
+		if (defaultValue instanceof Float) return "F";
+		if (defaultValue instanceof Character) return "C";
+		if (defaultValue instanceof Boolean) return "B";
+		return getType(defaultValue.getClass());
+	}
+	
+	protected void writeTo(StringBuilder builder) {
+		if (!description.isEmpty()) {
+			builder.append("\t# ");
+			builder.append(description);
+		}
+		builder.append("\n\t@default: ");
+		builder.append(defaultValue.toString());
+		builder.append("\n\t");
+		String type = getType();
+		if (!"~null~".contentEquals(type)) {
+			builder.append("<");
+			builder.append(type);
+			builder.append(">");
+		}
+		builder.append(propertyName);
+		builder.append(": ");
+		builder.append(currentValue.toString());
+	}
+	
+	private static Object parseValue(String type, String value) {
+		if (type.endsWith("[]")) {
+			type = type.substring(0, type.length() - 2);
+			String[] values = value.substring(1, value.length() -1).split(", ");
+			Object[] arr = new Object[values.length];
+			for (int i = 0; i < arr.length; i++) {
+				arr[i] = parseValue(type, values[i]);
+			}
+			return arr;
+		}
+		if ("S".contentEquals(type)) return value;
+		if ("I".contentEquals(type)) return Integer.valueOf(value);
+		if ("F".contentEquals(type)) return Float.valueOf(value);
+		if ("C".contentEquals(type)) return Character.valueOf(value.toCharArray()[0]);
+		if ("B".contentEquals(type)) return Character.valueOf(value.toCharArray()[0]);
+		Class typeClass = getTypeClass(type);
+		if (typeClass != null) {
+			try {
+				if (IStringable.class.isAssignableFrom(typeClass)) {
+					return ((IStringable)typeClass.newInstance()).valueOf(value);
+				} else {
+					Method m = typeClass.getMethod("valueOf", String.class);
+					if (!m.isAccessible()) {
+						m.setAccessible(true);
+					}
+					return m.invoke(typeClass.newInstance(), value);
+				}
+			} catch (Throwable e) {
+				e.printStackTrace();
+			}
+		}
+		return null;
+	}
+	
+	public static boolean hasType(Class type) {
+		return classToType.containsKey(type);
+	}
+	
+	public static boolean hasType(String typeString) {
+		return typeToClass.containsKey(typeString);
+	}
+	
+	public static String getType(Class type) {
+		if (hasType(type)) {
+			return classToType.get(type);
+		} else {
+			if (type.isArray()) {
+				return getType(type.getComponentType()) + "[]";
+			}
+		}
+		return "~null~";
+	}
+	
+	public static Class getTypeClass(String typeString) {
+		if (hasType(typeString)) {
+			return typeToClass.get(typeString);
+		}
+		return null;
+	}
+	
+	public static void registerType(Class<? extends IStringable> type, String typeString) {
+		classToType.put(type, typeString);
+		typeToClass.put(typeString, type);
+	}
+}

--- a/src/com/blazeloader/util/config/Properties.java
+++ b/src/com/blazeloader/util/config/Properties.java
@@ -72,7 +72,7 @@ public class Properties implements IConfig {
 		StringBuilder builder = new StringBuilder();
 		for (Section i : sections.values()) {
 			i.writeTo(builder);
-			builder.append("\n");
+			builder.append("\r\n");
 		}
 		writer.append(builder.toString());
 	}
@@ -80,9 +80,13 @@ public class Properties implements IConfig {
 	
 	protected void readFrom(List<String> lines) {
 		while (lines.size() > 0) {
-			Section section = new Section(this, lines);
-			if (section.loaded) {
-				sections.put(section.getName(), section);
+			try {
+				Section section = new Section(this, lines);
+				if (section.loaded) {
+					sections.put(section.getName(), section);
+				}
+			} catch (Throwable e) {
+				e.printStackTrace();
 			}
 		}
 	}
@@ -92,6 +96,14 @@ public class Properties implements IConfig {
 	}
 	
 	public String applyDescriptionRegexString(String description) {
-		return description.replaceAll("\n\r|\n|\r", "<br>").replaceAll("\t(\t)*", " ");
+		return description.replaceAll("\t(\t)*", " ");
+	}
+	
+	public String popNextLine(List<String> lines) {
+		String next = "";
+		do {
+			next = lines.remove(0).trim();
+		} while (next.isEmpty());
+		return next;
 	}
 }

--- a/src/com/blazeloader/util/config/Properties.java
+++ b/src/com/blazeloader/util/config/Properties.java
@@ -1,0 +1,97 @@
+package com.blazeloader.util.config;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+
+public class Properties implements IConfig {
+	private final HashMap<String, Section> sections = new HashMap<String, Section>();
+	
+	private File file;
+	
+	public Properties(File file) {
+		load(file);
+	}
+	
+	public void load(File file) {
+		if (file.exists() && !(file.canRead() && file.isFile())) {
+			throw new IllegalArgumentException("Given file is not a file or is not accessible.");
+		}
+		this.file = file;
+		try {
+			if (file.exists()) {
+				List<String> lines = FileUtils.readLines(file);
+				readFrom(lines);
+			} else {
+				file.createNewFile();
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+	
+	public void save() {
+		try {
+			FileWriter writer = new FileWriter(file);
+			writeTo(writer);
+			writer.close();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+	
+	protected boolean hasSection(String section) {
+		return sections.containsKey(section);
+	}
+	
+	public boolean has(String section, String name) {
+		if (hasSection(section)) {
+			return sections.get(section).has(name);
+		}
+		return false;
+	}
+	
+	public <T> Prop<T> getProperty(String section, String name, T defaultValue) {
+		return getSection(section).get(name, defaultValue);
+	}
+	
+	public Section getSection(String section) {
+		if (hasSection(section)) {
+			return sections.get(section);
+		}
+		Section result = new Section(this, section);
+		sections.put(section, result);
+		return result;
+	}
+	
+	protected void writeTo(FileWriter writer) throws IOException {
+		StringBuilder builder = new StringBuilder();
+		for (Section i : sections.values()) {
+			i.writeTo(builder);
+			builder.append("\n");
+		}
+		writer.append(builder.toString());
+	}
+	
+	
+	protected void readFrom(List<String> lines) {
+		while (lines.size() > 0) {
+			Section section = new Section(this, lines);
+			if (section.loaded) {
+				sections.put(section.getName(), section);
+			}
+		}
+	}
+	
+	public String applyNameRegexString(String name) {
+		return name.replaceAll("<|>|\t(\t)*|\n(\n)*|\r(\r)*| ", "_");
+	}
+	
+	public String applyDescriptionRegexString(String description) {
+		return description.replaceAll("\n\r|\n|\r", "<br>").replaceAll("\t(\t)*", " ");
+	}
+}

--- a/src/com/blazeloader/util/config/Section.java
+++ b/src/com/blazeloader/util/config/Section.java
@@ -1,0 +1,75 @@
+package com.blazeloader.util.config;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class Section implements IPropertyGroup {
+	private final HashMap<String, Prop> properties = new HashMap<String, Prop>();
+	
+	private final IConfig cfg;
+	
+	private String description = "";
+	
+	private String sectionName;
+	protected boolean loaded = false;
+	
+	public Section(IConfig config, List<String> lines) {
+		cfg = config;
+		String first = lines.get(0);
+		lines.remove(0);
+		if (first.startsWith("#")) {
+			description = first.substring(1, first.length());
+			first = lines.get(0);
+		}
+		sectionName = first.substring(0, first.length() - 2);
+		do {
+			Prop next = new Prop(cfg, lines);
+			if (next.loaded) {
+				properties.put(next.propertyName, next);
+			}
+		} while (lines.get(0).indexOf("}") != 0);
+		loaded = true;
+	}
+	
+	public Section(IConfig config, String sectionName) {
+		cfg = config;
+		sectionName = cfg.applyNameRegexString(sectionName);
+	}
+	
+	
+	public String getName() {
+		return sectionName;
+	}
+	
+	public void setDescription(String desc) {
+		if (desc == null) {
+			description = "";
+		} else {
+			description = cfg.applyDescriptionRegexString(desc);
+		}
+	}
+	
+	public boolean has(String key) {
+		return properties.containsKey(key);
+	}
+	
+	public <T> Prop<T> get(String key, T def) {
+		if (has(key)) {
+			return properties.get(key);
+		}
+		
+		Prop<T> result = new Prop<T>(cfg, key, def);
+		properties.put(key, result);
+		return result;
+	}
+	
+	protected void writeTo(StringBuilder builder) {
+		builder.append(sectionName);
+		builder.append(" {\n");
+		for (Prop i : properties.values()) {
+			i.writeTo(builder);
+			builder.append("\n");
+		}
+		builder.append("}");
+	}
+}


### PR DESCRIPTION
Cleaned up a few things and added fancy config files.

This is a reimplementation of the config systme I had for Manilla, except with much cleaner and much fewer code as well as types being stored inline in the properties files instead of a separate mappings file.

    #haha! Comments :D
    testSection {
    	#Ha even more comments!!!!!!!!!!!!!!!!!!!!!!!!:D:D:D:D
    	#I liek catfaces :3
    	@default: "testValue"
    	testProperty<S>: "something else"
    }


Properties are grouped into sections and comments can be added to both sections and individual properties. Comments can be as big and have as many lines as you want. For the most part white-space and indentation makes no difference when reading but files will be reformatted as above when it saves.