### PR TITLE
You know what the absolute best way to find holes in an API is?

### DIFF
--- a/src/com/blazeloader/api/block/ApiBlock.java
+++ b/src/com/blazeloader/api/block/ApiBlock.java
@@ -13,7 +13,6 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemMultiTexture;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 
 import java.util.HashMap;
@@ -112,7 +111,9 @@ public class ApiBlock {
     
     /**
      * Utility method to register a block.
-     * Will register the block together with an item and setup unlocalized names for both.
+     * Will register the block together with an item and assign unlocalized names for both with the following format:
+     * <p>
+     * {mod}.{block name}
      *
      * @param id        The ID of the block.
      * @param mod        The domain used for this mod. eg. "minecraft:stone" has the domain "minecraft"
@@ -122,7 +123,7 @@ public class ApiBlock {
      * @return the block for simplicity
      */
     public static <T extends Block> T quickRegisterBlock(int id, String mod, String name, T block) {
-        return registerBlock(id, new ResourceLocation(mod, name), (T) block.setUnlocalizedName(name), (new ItemBlock(block)).setUnlocalizedName(name));
+        return registerBlock(id, new ResourceLocation(mod, name), (T) block.setUnlocalizedName(mod + "." + name), (new ItemBlock(block)).setUnlocalizedName(mod + "." + name));
     }
 
     /**
@@ -291,16 +292,5 @@ public class ApiBlock {
     		Blocks.air = air;
     	}
     	//Switched to using Mumfry's implementation as it supports setting the static field as well as forcing past Forge.
-    }
-    
-    /**
-     * Registers or replaces a TileEntity
-     *
-     * @param clazz Tile entity class
-     * @param name  Entity name. Used as its id.
-     */
-    public static void registerTileEntity(Class<? extends TileEntity> clazz, String name) {
-        TileEntity.classToNameMap.put(clazz, name);
-        TileEntity.nameToClassMap.put(name, clazz);
     }
 }

--- a/src/com/blazeloader/api/client/render/ApiRenderBlock.java
+++ b/src/com/blazeloader/api/client/render/ApiRenderBlock.java
@@ -4,9 +4,49 @@ import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BlockModelShapes;
 import net.minecraft.client.renderer.block.statemap.IStateMapper;
+import net.minecraft.item.Item;
 
 public class ApiRenderBlock {
-    
+	
+	/**
+	 * Registers a block with a fallback texture for use with particles.
+	 * <p>
+	 * Useful for blocks like chests that are not rendered with .json models.
+	 * 
+	 * 
+	 * 
+	 * @param block			The block to register
+	 * @param texturePath	Texture to use. eg. "minecraft:blocks/planks_oak" is used for chests and signs.
+	 */
+	public static void registerFallbackTexture(Block block, String texturePath) {
+		BlockRenderRegistry.specialRenderBlocks.put(block, texturePath);
+	}
+	
+	/**
+	 * Registers a block with the render engine to use a specific model for the given data value. 
+	 * <p>
+	 * Same as:
+	 * <br><code>registerBlock(block, 0, identifier);</code>
+	 * 
+	 * @param item			the block to register
+	 * @param subType		metadata value
+	 * @param identifier	String identifier for the model that the game must use
+	 */
+	public static void registerBlock(Block block, String identifier) {
+		registerBlock(block, 0, identifier);
+	}
+	
+	/**
+	 * Registers a block with the render engine to use a specific model for the given data value. 
+	 * 
+	 * @param item			the block to register
+	 * @param subType		metadata value
+	 * @param identifier	String identifier for the model that the game must use
+	 */
+	public static void registerBlock(Block block, int subType, String identifier) {
+		ApiRenderItem.registerItem(Item.getItemFromBlock(block), subType, identifier);
+	}
+	
     /**
      * Registers a mapper for the given block that takes a given BlockState and gives back a prebaked model.
      *  

--- a/src/com/blazeloader/api/client/render/ApiRenderItem.java
+++ b/src/com/blazeloader/api/client/render/ApiRenderItem.java
@@ -1,26 +1,11 @@
 package com.blazeloader.api.client.render;
 
-import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.item.Item;
 
 public class ApiRenderItem {
-	
-	/**
-	 * Registers a block with the render engine to use a specific model for the given data value. 
-	 * <p>
-	 * Same as:
-	 * <br><code>registerBlock(block, 0, identifier);</code>
-	 * 
-	 * @param item			the block to register
-	 * @param subType		metadata value
-	 * @param identifier	String identifier for the model that the game must use
-	 */
-	public static void registerBlock(Block block, String identifier) {
-		registerBlock(block, 0, identifier);
-	}
 	
 	/**
 	 * Registers an item with the render engine to use a specific model. 
@@ -34,18 +19,7 @@ public class ApiRenderItem {
 	public static void registerItem(Item item, String identifier) {
 		registerItem(item, 0, identifier);
 	}
-	
-	/**
-	 * Registers a block with the render engine to use a specific model for the given data value. 
-	 * 
-	 * @param item			the block to register
-	 * @param subType		metadata value
-	 * @param identifier	String identifier for the model that the game must use
-	 */
-	public static void registerBlock(Block block, int subType, String identifier) {
-		registerItem(Item.getItemFromBlock(block), subType, identifier);
-	}
-	
+		
 	/**
 	 * Registers an item with the render engine to use a specific model for the given item data. 
 	 * 
@@ -54,7 +28,7 @@ public class ApiRenderItem {
 	 * @param identifier	String identifier for the model that the game must use
 	 */
 	public static void registerItem(Item item, int subType, String identifier) {
-		Minecraft.getMinecraft().renderItem.getItemModelMesher().register(item, subType, new ModelResourceLocation(identifier, "inventory"));
+		Minecraft.getMinecraft().getRenderItem().getItemModelMesher().register(item, subType, new ModelResourceLocation(identifier, "inventory"));
 	}
 	
 	/**
@@ -68,6 +42,6 @@ public class ApiRenderItem {
 	 * @param mesh	A mesh definition used to render the model for this item
 	 */
 	public static void registerItem(Item item, ItemMeshDefinition mesh) {
-		Minecraft.getMinecraft().renderItem.getItemModelMesher().register(item, mesh);
+		Minecraft.getMinecraft().getRenderItem().getItemModelMesher().register(item, mesh);
 	}
 }

--- a/src/com/blazeloader/api/client/render/BlockRenderRegistry.java
+++ b/src/com/blazeloader/api/client/render/BlockRenderRegistry.java
@@ -1,0 +1,17 @@
+package com.blazeloader.api.client.render;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.block.Block;
+
+public class BlockRenderRegistry {
+	protected static final Map<Block, String> specialRenderBlocks = new HashMap<Block, String>();
+	
+	public static String lookupTexture(Block block) {
+		if (specialRenderBlocks.containsKey(block)) {
+			return specialRenderBlocks.get(block);
+		}
+		return null;
+	}
+}

--- a/src/com/blazeloader/api/entity/ApiEntity.java
+++ b/src/com/blazeloader/api/entity/ApiEntity.java
@@ -4,6 +4,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.world.biome.BiomeGenBase.SpawnListEntry;
@@ -28,7 +29,18 @@ public class ApiEntity {
     public static void registerEntityType(Class<? extends Entity> entityClass, String entityName, int entityId) {
         EntityList.addMapping(entityClass, entityName, entityId);
     }
-
+    
+    /**
+     * Registers or replaces a TileEntity
+     *
+     * @param clazz Tile entity class
+     * @param name  Entity name. Used as its id.
+     */
+    public static void registerTileEntity(Class<? extends TileEntity> clazz, String name) {
+        TileEntity.classToNameMap.put(clazz, name);
+        TileEntity.nameToClassMap.put(name, clazz);
+    }
+    
     /**
      * Registers a spawn egg for a given entity type.
      *
@@ -135,6 +147,16 @@ public class ApiEntity {
      */
     public static int getEntityID(Entity entity) {
         return EntityList.getEntityID(entity);
+    }
+    
+    /**
+     * Gets the string id for the given TileEntity
+     * 
+     * @param entity	The tile entity
+     * @return the String ID for the tile entity
+     */
+    public static String getTileEntityID(TileEntity entity) {
+    	return (String)TileEntity.classToNameMap.get(entity.getClass());
     }
 
     /**

--- a/src/com/blazeloader/api/item/ApiItem.java
+++ b/src/com/blazeloader/api/item/ApiItem.java
@@ -13,6 +13,26 @@ import net.minecraft.util.ResourceLocation;
 public class ApiItem {
 	
     /**
+     * Utility method to register an item.
+     * Will assign a name to the item before registering.
+     * <p>
+     * Names will have the following format:
+     * <br>
+     * {mod}.{item name}
+     * <p>
+     * Registers an item in the game registry.
+     *
+     * @param id    The item ID
+     * @param name  The item name
+     * @param item  The item itself
+     *
+     * @return the item for simplicity
+     */
+    public static <T extends Item> T quickRegisterItem(int id, String mod, String name, T item) {
+        return registerItem(id, new ResourceLocation(mod, name), (T)item.setUnlocalizedName(mod + "." + name));
+    }
+	
+    /**
      * Registers an item in the game registry.
      *
      * @param id    The item ID

--- a/src/com/blazeloader/api/world/WorldSavedDataCollection.java
+++ b/src/com/blazeloader/api/world/WorldSavedDataCollection.java
@@ -1,0 +1,19 @@
+package com.blazeloader.api.world;
+
+import net.minecraft.world.World;
+import net.minecraft.world.WorldSavedData;
+
+public abstract class WorldSavedDataCollection extends WorldSavedData {
+	public WorldSavedDataCollection(String name) {
+		super(name);
+	}
+	
+	/**
+	 * In the case of multiple items initialises each one.
+	 * <p>
+	 * Used in VillagerCollection and made available to mod added WorldSaveData.
+	 * 
+	 * @param worldIn	The world this collection is being initialised to.
+	 */
+	public abstract void setWorldsForAll(World worldIn);
+}

--- a/src/com/blazeloader/bl/main/BLMain.java
+++ b/src/com/blazeloader/bl/main/BLMain.java
@@ -128,7 +128,7 @@ public class BLMain {
     public void init() {
         isClient = supportsClient();
     }
-
+    
     public boolean supportsClient() {
         return false;
     }

--- a/src/com/blazeloader/bl/main/BLMainClient.java
+++ b/src/com/blazeloader/bl/main/BLMainClient.java
@@ -17,6 +17,7 @@ import com.mumfrey.liteloader.launch.LoaderProperties;
  * Client BLMain.
  */
 public class BLMainClient extends BLMain {
+	
     BLMainClient(LoaderEnvironment environment, LoaderProperties properties) {
         super(environment, properties);
     }

--- a/src/com/blazeloader/bl/main/BlazeLoaderCoreProvider.java
+++ b/src/com/blazeloader/bl/main/BlazeLoaderCoreProvider.java
@@ -41,12 +41,12 @@ public class BlazeLoaderCoreProvider implements CoreProvider {
     
     @Override
     public void onPostInitComplete(LiteLoaderMods mods) {
-
+    	EventHandlerClient.eventStart();
     }
     
     @Override
     public void onStartupComplete() {
-        EventHandlerClient.eventStart();
+        
     }
     
     @Override

--- a/src/com/blazeloader/event/handlers/EventHandler.java
+++ b/src/com/blazeloader/event/handlers/EventHandler.java
@@ -64,6 +64,10 @@ public class EventHandler {
     }
     //
     
+    public static void eventInit(ReturnEventInfo<WorldServer, World> event) {
+    	worldEventHandlers.all().onWorldInit(event.getSource());
+    }
+    
     public static void eventPlayerLoggedIn(EventInfo<ServerConfigurationManager> event, EntityPlayerMP player) {
         playerEventHandlers.all().onPlayerLoginMP(event.getSource(), player);
     }

--- a/src/com/blazeloader/event/handlers/client/InternalEventHandlerClient.java
+++ b/src/com/blazeloader/event/handlers/client/InternalEventHandlerClient.java
@@ -1,12 +1,20 @@
 package com.blazeloader.event.handlers.client;
 
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.BlockModelShapes;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.IBakedModel;
 import net.minecraft.client.resources.model.ModelBakery;
+import net.minecraft.client.resources.model.ModelManager;
 import net.minecraft.client.settings.KeyBinding;
 
+import com.blazeloader.api.client.render.BlockRenderRegistry;
 import com.blazeloader.api.item.ItemRegistry;
 import com.blazeloader.event.handlers.EventHandler;
 import com.mumfrey.liteloader.transformers.event.EventInfo;
+import com.mumfrey.liteloader.transformers.event.ReturnEventInfo;
 
 /**
  * Event handler for events that are not passed to mods, but rather to BL itself
@@ -33,5 +41,19 @@ public class InternalEventHandlerClient {
 	
     public static void eventRegisterVariantNames(EventInfo<ModelBakery> event) {
     	ItemRegistry.instance().insertItemVariantNames(event.getSource().variantNames);
+    }
+    
+    public static void eventGetTexture(ReturnEventInfo<BlockModelShapes, TextureAtlasSprite> event, IBlockState state) {
+    	Block block = state.getBlock();
+        IBakedModel model = event.getSource().getModelForState(state);
+        ModelManager manager = event.getSource().getModelManager();
+        
+        if (model == null || model == manager.getMissingModel()) {
+        	String texture = BlockRenderRegistry.lookupTexture(block);
+        	if (texture != null) {
+        		event.setReturnValue(manager.getTextureMap().getAtlasSprite(texture));
+        		event.cancel();
+        	}
+        }
     }
 }

--- a/src/com/blazeloader/event/listeners/WorldListener.java
+++ b/src/com/blazeloader/event/listeners/WorldListener.java
@@ -22,4 +22,10 @@ public interface WorldListener extends BLMod {
      * @param world The world being ticked.
      */
     public void onServerTick(WorldServer world);
+    
+    /**
+     * Called when a world is loaded
+     * @param world	The world being loaded
+     */
+    public void onWorldInit(WorldServer world);
 }

--- a/src/com/blazeloader/event/transformers/BLEventInjectionTransformer.java
+++ b/src/com/blazeloader/event/transformers/BLEventInjectionTransformer.java
@@ -75,6 +75,7 @@ public class BLEventInjectionTransformer extends EventInjectionTransformer {
         addBLEvent(EventSide.INTERNAL, "net.minecraft.world.chunk.Chunk.populateChunk (Lnet/minecraft/world/chunk/IChunkProvider;Lnet/minecraft/world/chunk/IChunkProvider;II)V", beforeReturn);
         addBLEvent(EventSide.SERVER, "net.minecraft.world.chunk.Chunk.onChunkLoad ()V", beforeReturn);
         addBLEvent(EventSide.SERVER, "net.minecraft.world.chunk.Chunk.onChunkUnload ()V", beforeReturn);
+        addBLEvent(EventSide.SERVER, "net.minecraft.world.WorldServer.init ()Lnet/minecraft/world/World;", beforeReturn);
 		addBLEvent(EventSide.INTERNAL, "net.minecraft.entity.Entity.writeToNBT (Lnet/minecraft/nbt/NBTTagCompound;)V", beforeReturn);
         addBLEvent(EventSide.INTERNAL, "net.minecraft.entity.Entity.readFromNBT (Lnet/minecraft/nbt/NBTTagCompound;)V", beforeReturn);
         addBLEvent(EventSide.INTERNAL, "net.minecraft.entity.Entity.copyDataFromOld (Lnet/minecraft/entity/Entity;)V", beforeReturn);

--- a/src/com/blazeloader/event/transformers/BLEventInjectionTransformerClient.java
+++ b/src/com/blazeloader/event/transformers/BLEventInjectionTransformerClient.java
@@ -24,6 +24,7 @@ public class BLEventInjectionTransformerClient extends BLEventInjectionTransform
         addBLEvent(EventSide.INTERNAL, "net.minecraft.client.ClientBrandRetriever.getClientModName ()Ljava/lang/String;", beforeReturn);
         addBLEvent(EventSide.INTERNAL_CLIENT, "net.minecraft.client.resources.model.ModelBakery.registerVariantNames ()V", beforeReturn);
         addBLEvent(EventSide.INTERNAL_CLIENT, "net.minecraft.client.Minecraft.dispatchKeypresses ()V", beforeReturn);
+        addBLEvent(EventSide.INTERNAL_CLIENT, "net.minecraft.client.renderer.BlockModelShapes.getTexture (Lnet/minecraft/block/state/IBlockState;)Lnet/minecraft/client/renderer/texture/TextureAtlasSprite;");
     }
     
     @Override


### PR DESCRIPTION
Try to actually use it to make a mod. [Majic Chests](https://github.com/Sollace/Majic-Chests) runs entirely off of Blazeloader. It adds a new type of chest that can only be opened using a renamed key.

Opening the chest gives you an inventory associated with that key and can be accessed from any other Majic Chest using a key of the same name.


Some changes/additions I had to make to get this to work:
 - Added hooks to store data in the world storage (like village data)
 - Added registerFallbackTexture for blocks that don't use the normal json models
 - Added a quickRegister method for items for consistency
 - quickRegister methods now give items and blocks an unlocalisedname consisting of both the mod name and block name.

Fixes:
 - Fixed eventStart being triggered too late (after liteloader reloads the resource manager). That should resolve any issues with blockmodels/textures not showing.

I also regrouped some api methods to make them a bit easier to find.