### PR TITLE
Fixing some more things

### DIFF
--- a/src/com/blazeloader/api/achievement/ApiAchievement.java
+++ b/src/com/blazeloader/api/achievement/ApiAchievement.java
@@ -1,8 +1,10 @@
 package com.blazeloader.api.achievement;
 
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.stats.Achievement;
+import net.minecraft.stats.StatisticsFile;
 
 public class ApiAchievement {
     /**
@@ -13,6 +15,33 @@ public class ApiAchievement {
      */
     public static void unlockAchievement(EntityPlayer player, Achievement achievement) {
         player.triggerAchievement(achievement);
+    }
+    
+    /**
+     * The opposite of unlock achievement. If the player has previously unlocked the achievement will reset it to its initial state.
+     * 
+     * @param player		The player who has achieved
+     * @param achievement	What the player has achieved
+     */
+    public static void lockAchievement(EntityPlayerMP player, Achievement achievement) {
+		StatisticsFile stats = player.getStatFile();
+		if (stats.hasAchievementUnlocked(achievement)) {
+				//setStatValue
+			stats.func_150873_a(player, achievement, 0);
+			    //sendStatUpdate
+			stats.func_150876_a(player);
+		}
+    }
+    
+    /**
+     * Checks if the player has unlocked the given achievement.
+     * 
+     * @param player		The player to check
+     * @param achievement	The achievement to check for
+     * @return	True if the player has that achievement, false otherwise.
+     */
+    public static boolean hasAchievementUnlocked(EntityPlayerMP player, Achievement achievement) {
+		return player.getStatFile().hasAchievementUnlocked(achievement);
     }
 
     /**

--- a/src/com/blazeloader/api/client/render/ApiRenderPlayer.java
+++ b/src/com/blazeloader/api/client/render/ApiRenderPlayer.java
@@ -15,7 +15,7 @@ public class ApiRenderPlayer {
 	 * 
 	 * @param skinType	The player skin type to replace
 	 * @param renderer	The renderer to use
-	 * @return	The passed in SKinType for chaining
+	 * @return	The passed in SkinType for chaining
 	 */
 	public static SkinType setPlayerRenderer(SkinType skinType, RenderPlayer renderer) {
 		if (defaultRenderer == null) {
@@ -67,7 +67,7 @@ public class ApiRenderPlayer {
 	public static RenderPlayer getPlayerRenderer(SkinType skinType) {
 		RenderPlayer result = skinMap().get(skinType.key);
 		if (result == null) {
-			result = skinMap().get("default");
+			return skinMap().get(SkinType.STEVE.key);
 		}
 		return result;
 	}
@@ -76,7 +76,7 @@ public class ApiRenderPlayer {
 	 * Gets a renderer for the given player based on the type of skin they use.
 	 * 
 	 * @param player	The EntityPlayer to render
-	 * @return	A render player for the given player
+	 * @return	A player renderer for the given player
 	 */
 	public static RenderPlayer getPlayerRenderer(EntityPlayer player) {
 		return (RenderPlayer)ApiClient.getRenderManager().getEntityRenderObject(player);

--- a/src/com/blazeloader/api/compatibility/Wall.java
+++ b/src/com/blazeloader/api/compatibility/Wall.java
@@ -6,10 +6,10 @@ import java.util.*;
 /**
  * A wall for mods to communicate between each other by setting and getting values by a string identifier.
  */
-public class Wall implements Iterable<Wall.Entry> {
+public final class Wall implements Iterable<Wall.Entry> {
     private static Map<String, Wall.Entry> wallMap = new HashMap<String, Wall.Entry>();
     
-    private static Wall instance = new Wall();
+    private static final Wall instance = new Wall();
     
     /**
      * Gets a wall object for iteration and select functions from List.

--- a/src/com/blazeloader/api/entity/ApiProjectile.java
+++ b/src/com/blazeloader/api/entity/ApiProjectile.java
@@ -1,0 +1,77 @@
+package com.blazeloader.api.entity;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.IProjectile;
+import net.minecraft.entity.projectile.EntityArrow;
+import net.minecraft.entity.projectile.EntityFireball;
+import net.minecraft.entity.projectile.EntityFishHook;
+import net.minecraft.entity.projectile.EntityThrowable;
+
+public class ApiProjectile {
+	
+	/**
+	 * Checks if the given entity is a projectile.
+	 */
+	public static boolean isProjectile(Entity e) {
+		return e instanceof IProjectile || e instanceof EntityFireball || e instanceof EntityFishHook;
+	}
+	
+	/**
+	 * Checks if an entity is a thrown projectile.
+	 */
+	public static boolean isThrowable(Entity e) {
+		return e instanceof EntityThrowable || e instanceof EntityArrow || e instanceof EntityFireball || e instanceof EntityFishHook; 
+	}
+	
+	/**
+	 * Checks if the given projectile was thrown by the given entity
+	 */
+	public static boolean isProjectileThrownBy(Entity throwable, Entity e) {
+		return e != null && e.equals(getThrowingEntity(throwable));
+	}
+	
+	/**
+	 * Gets the thrower for a projectile or null
+	 */
+	public static Entity getThrowingEntity(Entity throwable) {
+		if (throwable instanceof EntityThrowable) return ((EntityThrowable)throwable).getThrower();
+		if (throwable instanceof EntityArrow) return ((EntityArrow)throwable).shootingEntity;
+		if (throwable instanceof EntityFireball) return ((EntityFireball)throwable).shootingEntity;
+		if (throwable instanceof EntityFishHook) return ((EntityFishHook)throwable).angler;
+		return null;
+	}
+	
+	/**
+	 * Sets the velocity and heading for a projectile.
+	 * 
+	 * @param throwable		The projectile
+	 * @param x				X Direction component
+	 * @param y				Y Direction component
+	 * @param z				Z Direction component
+	 * @param velocity		Velocity
+	 * @param inaccuracy	Inaccuracy
+	 * @return				True the projectile's heading was set, false otherwise
+	 */
+	public static boolean setThrowableHeading(Entity throwable, double x, double y, double z, float velocity, float inaccuracy) {
+		if (throwable instanceof IProjectile) {
+			((IProjectile)throwable).setThrowableHeading(x, y, z, velocity, inaccuracy);
+			return true;
+		}
+		if (throwable instanceof EntityFishHook) {
+			((EntityFishHook)throwable).handleHookCasting(x, y, z, velocity, inaccuracy);
+			return true;
+		}
+		velocity = (float)Math.sqrt(velocity);
+		x *= velocity;
+		y *= velocity;
+		z *= velocity;
+		if (throwable instanceof EntityFireball) {
+			((EntityFireball)throwable).accelerationX = x;
+			((EntityFireball)throwable).accelerationY = y;
+			((EntityFireball)throwable).accelerationZ = z;
+			return true;
+		}
+		throwable.setVelocity(x, y, z);
+		return false;
+	}
+}

--- a/src/com/blazeloader/api/entity/profession/Professions.java
+++ b/src/com/blazeloader/api/entity/profession/Professions.java
@@ -20,11 +20,11 @@ public final class Professions {
 	public static Professions instance() {
 		return instance;
 	}
-		
+	
 	private Professions() { }
 	
 	public int randomProfessionId(Random rand) {
-		return 6;// rand.nextInt(professions.size() + 6);
+		return rand.nextInt(professions.size() + 6);
 	}
 	
 	public boolean hasId(int id) {

--- a/src/com/blazeloader/api/entity/properties/EntityPropertyManager.java
+++ b/src/com/blazeloader/api/entity/properties/EntityPropertyManager.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.UUID;
 
 import com.blazeloader.bl.main.BLMain;
+import com.blazeloader.util.data.INBTWritable;
 import com.mumfrey.liteloader.core.event.HandlerList;
 
 import net.minecraft.crash.CrashReportCategory;
@@ -16,7 +17,15 @@ import net.minecraft.world.World;
  */
 public class EntityPropertyManager {
 	
+	private static EntityPropertyManager instance = new EntityPropertyManager();
+	
 	private static final HashMap<UUID, Properties> mapping = new HashMap<UUID, Properties>();
+	
+	public static EntityPropertyManager instance() {
+		return instance;
+	}
+	
+	private EntityPropertyManager() { }
 	
 	public static void registerEntityProperties(Entity e, IEntityProperties p) {
 		if (e != null) {
@@ -47,7 +56,7 @@ public class EntityPropertyManager {
 		return null;
 	}
 	
-	public static void copyToEntity(Entity source, Entity destination) {
+	public void copyToEntity(Entity source, Entity destination) {
 		UUID key = source.getUniqueID();
 		if (mapping.containsKey(key)) {
 			Properties entry = mapping.get(key);
@@ -59,27 +68,27 @@ public class EntityPropertyManager {
 		}
 	}
 	
-	public static void entityDestroyed(Entity e) {
+	public void entityDestroyed(Entity e) {
 		if (mapping.containsKey(e.getUniqueID())) {
 			mapping.remove(e.getUniqueID());
 		}
 	}
 	
-	public static void entityinit(Entity e) {
+	public void entityinit(Entity e) {
 		UUID key = e.getUniqueID();
 		if (mapping.containsKey(key)) {
 			mapping.get(key).entityInit(e, e.worldObj);
 		}
 	}
 	
-	public static void onEntityUpdate(Entity e) {
+	public void onEntityUpdate(Entity e) {
 		UUID key = e.getUniqueID();
 		if (mapping.containsKey(key)) {
 			mapping.get(key).onEntityUpdate(e);
 		}
 	}
 	
-	public static void readFromNBT(Entity e, NBTTagCompound t) {
+	public void readFromNBT(Entity e, NBTTagCompound t) {
 		UUID key = e.getUniqueID();
 		if (mapping.containsKey(key)) {
 			//We have to make sure the registry's object remains with the entity after it's UUID is loaded from NBT
@@ -106,7 +115,7 @@ public class EntityPropertyManager {
 		}
 	}
 	
-	public static void writeToNBT(Entity e, NBTTagCompound t) {
+	public void writeToNBT(Entity e, NBTTagCompound t) {
 		UUID key = e.getUniqueID();
 		if (mapping.containsKey(key)) {
 			NBTTagCompound modsTag = new NBTTagCompound();
@@ -120,7 +129,7 @@ public class EntityPropertyManager {
 		}
 	}
 	
-	public static void addEntityCrashInfo(Entity e, CrashReportCategory section) {
+	public void addEntityCrashInfo(Entity e, CrashReportCategory section) {
 		UUID key = e.getUniqueID();
 		if (mapping.containsKey(key)) {
 			Properties p = mapping.get(key);
@@ -132,7 +141,7 @@ public class EntityPropertyManager {
 		}
 	}
 	
-	private static class Properties {
+	private static class Properties implements INBTWritable {
 		private final HandlerList<IEntityProperties> handlers = new HandlerList<IEntityProperties>(IEntityProperties.class);
 		
 		private Properties() {}

--- a/src/com/blazeloader/api/entity/properties/IEntityProperties.java
+++ b/src/com/blazeloader/api/entity/properties/IEntityProperties.java
@@ -1,14 +1,15 @@
 package com.blazeloader.api.entity.properties;
 
+import com.blazeloader.util.data.INBTWritable;
+
 import net.minecraft.crash.CrashReportCategory;
 import net.minecraft.entity.Entity;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 
 /**
  * Interface for entity extension classes
  */
-public interface IEntityProperties {
+public interface IEntityProperties extends INBTWritable {
 	
 	/**
 	 * Notifies this properties of who its owner is.
@@ -26,17 +27,6 @@ public interface IEntityProperties {
 	 * Called to update the entity's position/logic.
 	 */
 	public void onEntityUpdate(Entity e);
-	
-	/**
-	 * @param tagCompound
-	 */
-	public void writeToNBT(NBTTagCompound tagCompound);
-	
-	/**
-	 * 
-	 * @param tagCompound
-	 */
-	public void readFromNBT(NBTTagCompound tagCompund);
 	
 	/**
 	 * Used if the game crashes. Put stuff you want to know in the crash report from here.

--- a/src/com/blazeloader/api/particles/ParticleData.java
+++ b/src/com/blazeloader/api/particles/ParticleData.java
@@ -152,7 +152,7 @@ public final class ParticleData {
 	public ParticleData setVel(double x, double y, double z) {
 		velX = x;
 		velY = y;
-		velX = z;
+		velZ = z;
 		return this;
 	}
 	

--- a/src/com/blazeloader/event/handlers/EventHandler.java
+++ b/src/com/blazeloader/event/handlers/EventHandler.java
@@ -124,13 +124,13 @@ public class EventHandler {
     public static void initEntity(EventInfo<Entity> event, World w) {
     	if (!(event.getSource() instanceof EntityPlayer)) {
 	    	entityEventHandlers.all().onEntityConstructed(event.getSource());
-	    	EntityPropertyManager.entityinit(event.getSource());
+	    	EntityPropertyManager.instance().entityinit(event.getSource());
     	}
     }
     
     public static void initEntityPlayer(EventInfo<EntityPlayer> event, World w, GameProfile profile) {
     	entityEventHandlers.all().onEntityConstructed(event.getSource());
-    	EntityPropertyManager.entityinit(event.getSource());
+    	EntityPropertyManager.instance().entityinit(event.getSource());
     }
     
     public static void eventCollideWithPlayer(EventInfo<EntityPlayer> event, Entity entity) {

--- a/src/com/blazeloader/event/handlers/InternalEventHandler.java
+++ b/src/com/blazeloader/event/handlers/InternalEventHandler.java
@@ -4,8 +4,6 @@ import java.util.List;
 import java.util.Random;
 
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockTorch;
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.ClientBrandRetriever;
 import net.minecraft.command.CommandHandler;
 import net.minecraft.crash.CrashReport;
@@ -86,36 +84,36 @@ public class InternalEventHandler {
 	public static void eventOnEntityRemoved(EventInfo<World> event, Entity entity) {
 		if (entity.isDead) {
 			if (!(entity instanceof EntityPlayer)) {
-				EntityPropertyManager.entityDestroyed(entity);
+				EntityPropertyManager.instance().entityDestroyed(entity);
 			}
 		}
 	}
 	
 	public static void eventOnUpdate(EventInfo<Entity> event) {
-		EntityPropertyManager.onEntityUpdate(event.getSource());
+		EntityPropertyManager.instance().onEntityUpdate(event.getSource());
 	}
 	
     public static void eventWriteToNBT(EventInfo<Entity> event, NBTTagCompound tag) {
-    	EntityPropertyManager.writeToNBT(event.getSource(), tag);
+    	EntityPropertyManager.instance().writeToNBT(event.getSource(), tag);
     }
     
     public static void eventReadFromNBT(EventInfo<Entity> event, NBTTagCompound tag) {
-    	EntityPropertyManager.readFromNBT(event.getSource(), tag);
+    	EntityPropertyManager.instance().readFromNBT(event.getSource(), tag);
     }
     
     public static void eventClonePlayer(EventInfo<EntityPlayer> event, EntityPlayer old, boolean respawnedFromEnd) {
-    	EntityPropertyManager.copyToEntity(old, event.getSource());
+    	EntityPropertyManager.instance().copyToEntity(old, event.getSource());
     	if (!old.getUniqueID().equals(event.getSource().getUniqueID())) {
-    		EntityPropertyManager.entityDestroyed(old);
+    		EntityPropertyManager.instance().entityDestroyed(old);
     	}
     }
     
     public static void eventCopyDataFromOld(EventInfo<Entity> event, Entity old) {
-    	EntityPropertyManager.copyToEntity(old, event.getSource());
+    	EntityPropertyManager.instance().copyToEntity(old, event.getSource());
     }
     
     public static void eventAddEntityCrashInfo(EventInfo<Entity> event, CrashReportCategory section) {
-    	EntityPropertyManager.addEntityCrashInfo(event.getSource(), section);
+    	EntityPropertyManager.instance().addEntityCrashInfo(event.getSource(), section);
     }
     
     public static void eventTrackEntity(EventInfo<EntityTracker> event, Entity entity) {

--- a/src/com/blazeloader/event/handlers/InternalEventHandler.java
+++ b/src/com/blazeloader/event/handlers/InternalEventHandler.java
@@ -142,4 +142,30 @@ public class InternalEventHandler {
     	int result = FurnaceFuels.getItemBurnTime(stack);
     	if (result > 0) event.setReturnValue(result);
     }
+    /*
+    //=============Torch events======
+    
+    public static void eventOnNeighborChangeInternal(ReturnEventInfo<BlockTorch, Boolean> event, World world, BlockPos pos, IBlockState state) {
+        EnumFacing opposite = ((EnumFacing)state.getValue(BlockTorch.FACING)).getOpposite();
+        pos = pos.offset(opposite);
+        Block block = world.getBlockState(pos).getBlock();
+        if (block instanceof ISided) {
+        	BlockTorch torch = event.getSource();
+        	if (((ISided)state.getBlock()).isSideSolid(world, pos, opposite)) {
+        		event.setReturnValue(true);
+        	}
+        }
+    }
+    
+    public static void canPlaceAt(ReturnEventInfo<BlockTorch, Boolean> event, World world, BlockPos pos, EnumFacing facing) {
+    	facing = facing.getOpposite();
+    	pos = pos.offset(facing);
+    	IBlockState state = world.getBlockState(pos);
+    	if (state.getBlock() instanceof ISided) {
+    		event.setReturnValue(((ISided)state.getBlock()).isSideSolid(world, pos, facing));
+    	}
+    }
+    
+    //==============================
+     Possibly out of our scope*/
 }

--- a/src/com/blazeloader/event/handlers/client/EventHandlerClient.java
+++ b/src/com/blazeloader/event/handlers/client/EventHandlerClient.java
@@ -13,6 +13,7 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityTracker;
 import net.minecraft.entity.EntityTrackerEntry;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.network.INetHandler;
 import net.minecraft.network.Packet;
@@ -20,12 +21,14 @@ import net.minecraft.network.PacketThreadUtil;
 import net.minecraft.network.play.INetHandlerPlayClient;
 import net.minecraft.network.play.server.S01PacketJoinGame;
 import net.minecraft.network.play.server.S09PacketHeldItemChange;
+import net.minecraft.network.play.server.S0DPacketCollectItem;
 import net.minecraft.network.play.server.S0EPacketSpawnObject;
 import net.minecraft.network.play.server.S2DPacketOpenWindow;
 import net.minecraft.profiler.Profiler;
 import net.minecraft.util.BlockPos;
 import net.minecraft.world.World;
 
+import com.blazeloader.api.client.ApiClient;
 import com.blazeloader.api.gui.CreativeTabGui;
 import com.blazeloader.event.handlers.EventHandler;
 import com.blazeloader.event.listeners.client.ClientBlockListener;
@@ -163,6 +166,22 @@ public class EventHandlerClient extends EventHandler {
 						event.cancel();
 					}
 	    		}
+	    	}
+    	}
+    }
+    
+    public static void eventHandleCollectItem(EventInfo<NetHandlerPlayClient> event, S0DPacketCollectItem packet) {
+    	if (inventoryEventHandlers.size() > 0) {
+	    	Minecraft mc = ApiClient.getClient();
+	    	Entity owner = mc.theWorld.getEntityByID(packet.getEntityID());
+	    	if (owner == null) owner = mc.thePlayer;
+	    	Entity item = mc.theWorld.getEntityByID(packet.getCollectedItemEntityID());
+	    	if (item != null) {
+	    		int amount = 1;
+	    		if (item instanceof EntityItem) {
+	    			amount = ((EntityItem)item).getEntityItem().stackSize;
+	    		}
+	    		inventoryEventHandlers.all().onItemPickup(owner, item, amount);
 	    	}
     	}
     }

--- a/src/com/blazeloader/event/listeners/InventoryListener.java
+++ b/src/com/blazeloader/event/listeners/InventoryListener.java
@@ -41,7 +41,6 @@ public interface InventoryListener extends BLMod {
 	 * @param itemEntity	The entity being picked up
 	 * @param amount		The number of items being picked up from this entity
 	 */
-	//TODO: Broken
 	public void onItemPickup(Entity entity, Entity itemEntity, int amount);
 	
 	/**

--- a/src/com/blazeloader/event/listeners/WorldListener.java
+++ b/src/com/blazeloader/event/listeners/WorldListener.java
@@ -8,20 +8,6 @@ import net.minecraft.world.WorldServer;
  * Server-side world events
  */
 public interface WorldListener extends BLMod {
-
-    /**
-     * Called when WorldServer.tickBlocksAndAmbiance is called.
-     *
-     * @param server The server calling tickBlocksAndAmbiance
-     */
-    public void onBlocksAndAmbianceTicked(WorldServer server);
-
-    /**
-     * Called when a server-side world is ticked.
-     *
-     * @param world The world being ticked.
-     */
-    public void onServerTick(WorldServer world);
     
     /**
      * Called when a world is loaded

--- a/src/com/blazeloader/event/transformers/BLEventInjectionTransformer.java
+++ b/src/com/blazeloader/event/transformers/BLEventInjectionTransformer.java
@@ -120,12 +120,14 @@ public class BLEventInjectionTransformer extends EventInjectionTransformer {
         addBLEvent(EventSide.SERVER, "net.minecraft.entity.player.EntityPlayer.fall (FF)V");
         addBLEvent(EventSide.SERVER, "net.minecraft.inventory.Container.slotClick (IIILnet/minecraft/entity/player/EntityPlayer;)Lnet/minecraft/item/ItemStack;", beforeReturn);
         
-        //FIXME: Disabled because for some reason we can't transform EntityLivingBase. It results in a java.lang.ClassCircularityException on EntityPlayer
+        //FIX ME: Disabled because for some reason we can't transform EntityLivingBase. It results in a java.lang.ClassCircularityException on EntityPlayer
         // addBLEvent(EventSide.SERVER, "net.minecraft.entity.EntityLivingBase.onItemPickup (Lnet/minecraft/entity/Entity;I)V");
-        //FIXME: Part 2: It seems the same problem extends to EntityPlayerMP as well. So we can't get access to that method at all.
+        //FIX ME: Part 2: It seems the same problem extends to EntityPlayerMP as well. So we can't get access to that method at all.
         // addBLEvent(EventSide.SERVER, "net.minecraft.entity.player.EntityPlayerMP.onItemPickup (Lnet/minecraft/entity/Entity;I)V");
-        //FIXME: Part 3: After looking into it a bit more the problem seems to be that liteloader produces an invalid class when transforming EntityLivingBase.
+        //FIX ME: Part 3: After looking into it a bit more the problem seems to be that liteloader produces an invalid class when transforming EntityLivingBase.
         // The transformation can be forced by catching the exception but the game will crash saying the "locals are too large".
+        
+        addBLConstructorEvent(EventSide.SERVER, "net.minecraft.network.play.server.S0DPacketCollectItem", new Object[] {int.class, int.class}, beforeReturn);
         
         addBLConstructorEvent(EventSide.SERVER, "net.minecraft.entity.Entity", new Object[] {BLOBF.getClass("net.minecraft.world.World", OBFLevel.MCP) }, beforeReturn);
         //Event fired separately to ensure players are fully setup

--- a/src/com/blazeloader/event/transformers/BLEventInjectionTransformerClient.java
+++ b/src/com/blazeloader/event/transformers/BLEventInjectionTransformerClient.java
@@ -18,6 +18,7 @@ public class BLEventInjectionTransformerClient extends BLEventInjectionTransform
         addBLEvent(EventSide.CLIENT, "net.minecraft.entity.EntityTrackerEntry.func_151260_c ()Lnet/minecraft/network/Packet;");
         addBLEvent(EventSide.CLIENT, "net.minecraft.client.network.NetHandlerPlayClient.handleOpenWindow (Lnet/minecraft/network/play/server/S2DPacketOpenWindow;)V");
         addBLEvent(EventSide.CLIENT, "net.minecraft.client.network.NetHandlerPlayClient.handleHeldItemChange (Lnet/minecraft/network/play/server/S09PacketHeldItemChange;)V");
+        addBLEvent(EventSide.CLIENT, "net.minecraft.client.network.NetHandlerPlayClient.handleCollectItem(Lnet.minecraft.network.play.server.S0DPacketCollectItem;)V");
         addBLEvent(EventSide.CLIENT, "net.minecraft.client.multiplayer.WorldClient.func_180503_b (Lnet/minecraft/util/BlockPos;Lnet/minecraft/block/state/IBlockState;)Z");
         addBLEvent(EventSide.CLIENT, "net.minecraft.client.particle.EffectRenderer.spawnEffectParticle (IDDDDDD[I)Lnet/minecraft/client/particle/EntityFX;");
         addBLEvent(EventSide.CLIENT, "net.minecraft.client.entity.EntityPlayerSP.setPlayerSPHealth (F)V", beforeReturn);

--- a/src/com/blazeloader/event/transformers/BLEventInjectionTransformerClient.java
+++ b/src/com/blazeloader/event/transformers/BLEventInjectionTransformerClient.java
@@ -18,7 +18,7 @@ public class BLEventInjectionTransformerClient extends BLEventInjectionTransform
         addBLEvent(EventSide.CLIENT, "net.minecraft.entity.EntityTrackerEntry.func_151260_c ()Lnet/minecraft/network/Packet;");
         addBLEvent(EventSide.CLIENT, "net.minecraft.client.network.NetHandlerPlayClient.handleOpenWindow (Lnet/minecraft/network/play/server/S2DPacketOpenWindow;)V");
         addBLEvent(EventSide.CLIENT, "net.minecraft.client.network.NetHandlerPlayClient.handleHeldItemChange (Lnet/minecraft/network/play/server/S09PacketHeldItemChange;)V");
-        addBLEvent(EventSide.CLIENT, "net.minecraft.client.network.NetHandlerPlayClient.handleCollectItem(Lnet.minecraft.network.play.server.S0DPacketCollectItem;)V");
+        addBLEvent(EventSide.CLIENT, "net.minecraft.client.network.NetHandlerPlayClient.handleCollectItem (Lnet/minecraft/network/play/server/S0DPacketCollectItem;)V");
         addBLEvent(EventSide.CLIENT, "net.minecraft.client.multiplayer.WorldClient.func_180503_b (Lnet/minecraft/util/BlockPos;Lnet/minecraft/block/state/IBlockState;)Z");
         addBLEvent(EventSide.CLIENT, "net.minecraft.client.particle.EffectRenderer.spawnEffectParticle (IDDDDDD[I)Lnet/minecraft/client/particle/EntityFX;");
         addBLEvent(EventSide.CLIENT, "net.minecraft.client.entity.EntityPlayerSP.setPlayerSPHealth (F)V", beforeReturn);

--- a/src/com/blazeloader/util/data/INBTWritable.java
+++ b/src/com/blazeloader/util/data/INBTWritable.java
@@ -1,0 +1,17 @@
+package com.blazeloader.util.data;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+public interface INBTWritable {
+	
+	/**
+	 * @param tagCompound
+	 */
+	public void writeToNBT(NBTTagCompound tagCompound);
+	
+	/**
+	 * 
+	 * @param tagCompound
+	 */
+	public void readFromNBT(NBTTagCompound tagCompound);
+}

--- a/src/com/blazeloader/util/shape/Cone.java
+++ b/src/com/blazeloader/util/shape/Cone.java
@@ -51,19 +51,19 @@ public class Cone implements IShape {
 	}
 	
 	public double getXOffset() {
-		return -rad/2;
+		return 0;
 	}
 	
 	public double getYOffset() {
-		return -height/2;
+		return 0;
 	}
 	
 	public double getZOffset() {
-		return -rad/2;
+		return 0;
 	}
 	
 	public Vec3 computePoint(Random rand) {
-		double pheta = MathHelper.getRandomDoubleInRange(rand, 0, Math.PI);
+		double pheta = MathHelper.getRandomDoubleInRange(rand, 0, Math.PI * 2);
 		double phi = Math.abs(Math.atan(rad / height));
 		
 		if (!hollow) {
@@ -71,12 +71,13 @@ public class Cone implements IShape {
 		}
 		
 		double radius = Math.tan(phi) * height;
-		double rho = Math.sqrt((height * height) + (radius * radius));
-		if (!hollow) {
-			rho = MathHelper.getRandomDoubleInRange(rand, 0, height);
-		}
+		double rho = MathHelper.getRandomDoubleInRange(rand, 0, height);
 		
-		return (new Vec3(rho * Math.sin(phi) * Math.cos(pheta) * stretch.xCoord,rho * Math.sin(phi) * Math.sin(pheta) * stretch.yCoord, rho * Math.cos(phi) * stretch.zCoord)).rotateYaw(yaw).rotatePitch(pitch);
+		double x = rho * Math.sin(phi) * Math.cos(pheta);
+		double y = rho * Math.sin(phi) * Math.sin(pheta);
+		double z = rho * Math.cos(phi);
+		
+		return (new Vec3(x * stretch.xCoord, y * stretch.yCoord, z * stretch.zCoord)).rotateYaw(yaw).rotatePitch(pitch);
 	}
 	
 	public Cone setRotation(float u, float v) {

--- a/src/com/blazeloader/util/shape/Sphere.java
+++ b/src/com/blazeloader/util/shape/Sphere.java
@@ -95,11 +95,17 @@ public class Sphere implements IShape {
 	}
 	
 	public Vec3 computePoint(Random rand) {
-		double rho = hollow ? rad : MathHelper.getRandomDoubleInRange(rand, 0, rad);
-		double pheta = MathHelper.getRandomDoubleInRange(rand, 0, Math.PI * 2);
-		double phi = MathHelper.getRandomDoubleInRange(rand, 0, Math.PI);
+		double rad = this.rad;
 		
-		return (new Vec3(rho * Math.sin(phi) * Math.cos(pheta) * stretch.xCoord,rho * Math.sin(phi) * Math.sin(pheta) * stretch.yCoord, rho * Math.cos(phi) * stretch.zCoord)).rotateYaw(yaw).rotatePitch(pitch);
+		if (!hollow) {
+			rad = MathHelper.getRandomDoubleInRange(rand, 0, rad);
+		}
+		
+		double z = MathHelper.getRandomDoubleInRange(rand, -rad, rad);
+		double phi = MathHelper.getRandomDoubleInRange(rand, 0, Math.PI * 2);
+		double theta = Math.asin(z / rad);
+		
+		return new Vec3(rad * Math.cos(theta) * Math.cos(phi) * stretch.xCoord, rad * Math.cos(theta) * Math.sin(phi) * stretch.yCoord, z * stretch.zCoord).rotateYaw(yaw).rotatePitch(pitch);
 	}
 	
 	public Sphere setRotation(float u, float v) {


### PR DESCRIPTION
The onItemPickup event is now implemented. I got  around the problem of being unable to inject into EntityPlayerMP and EntityLivingBase by listening for the packet instead. The upside to this is that the event will now be triggered on both the client and the server.

Removed few events that weren't implemented of used. They seemed to be left over from before the liteloader merge and aren't really needed since liteloader provides its own versions of these events.


I added an INBTWritable interface just to unify parts of the api. Now anything that can be written to NBT should use this interface.

I did think about adding something that would allow you to convert most mojang classes that can be written to NBT into an INBTWritable but wasn't too happy with how it was turning out.

Expanded on ApiAchievement.
You can now check if a player has the certain achievement already, and you can relock one that has already been obtained.

ApiProjectile contains some methods for working with thrown and shot entities. It can get out the entity that threw them is applicable as well as set their heading and velocity.

Fixed some minor bugs:
- Fixed particles spawning with the wrong velocity
- Fixed cones being positioned incorrectly
- Spheres will now generate points uniformly
- Fixed villagers always spawning with the same profession (6). That was some test I put in and forgot about.



Also something else I've been working on, and would like some feedback, is a bit of an api to standardise usages of energy for mods. It's based off of a similar thing I saw being done for M3L but is a bit more hands-off. It just provides a set of interfaces that if modders implement should allow their systems to work together more easily. [linky](https://github.com/Sollace/BlazeLoader/tree/energy/src/com/blazeloader/api/energy!)

@warriordog
